### PR TITLE
Fixing permissions on some files read by rabbitmq user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,4 +136,11 @@ chown rabbitmq:rabbitmq /etc/rabbitmq/advanced.config
 chmod 600 /etc/rabbitmq/advanced.config
 
 
-exec "$@"
+# Ownership by 'rabbitmq'
+[[ -e "${MQ_CA}" ]] && chown rabbitmq:rabbitmq "${MQ_CA}"
+[[ -e "${MQ_SERVER_CERT}" ]] && chown rabbitmq:rabbitmq "${MQ_SERVER_CERT}"
+[[ -e "${MQ_SERVER_KEY}" ]] && chown rabbitmq:rabbitmq "${MQ_SERVER_KEY}"
+find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+
+# Run as 'rabbitmq'
+exec su-exec rabbitmq "$@"


### PR DESCRIPTION
We `chown` a few files to the `rabbitmq` user and run `rabbitmq-server` under the `rabbitmq` user.