### PR TITLE
Change build cache source repository of mq service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ COPY entrypoint.sh /usr/local/bin/ega-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/ega-entrypoint.sh
 
+USER 100:101
+
 ENTRYPOINT ["/usr/local/bin/ega-entrypoint.sh"]
 
 CMD ["rabbitmq-server"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The following environment variables can be used to configure the broker:
 
 | Variable | Description |
 |---------:|:------------|
+| `MQ_VHOST` | Default vhost other than `/` |
+| `MQ_VERIFY` | Set to `verify_none` to disable verification of client certificate |
 | `MQ_USER` | Default user (with admin rights) |
 | `MQ_PASSWORD_HASH` | Password hash for the above user |
 | `CEGA_CONNECTION` | DSN URL for the shovels and federated queues with CentralEGA |
@@ -28,6 +30,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     environment:
+      - MQ_VHOST=vhost
       - MQ_USER=admin
       - MQ_PASSWORD_HASH=4tHURqDiZzypw0NTvoHhpn8/MMgONWonWxgRZ4NXgR8nZRBz
       - CEGA_CONNECTION

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker build \
-       --cache-from egarchive/lega-mq:stable \
+       --cache-from nbisweden/ega-mq:m7 \
        --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
        --build-arg SOURCE_COMMIT=$(git rev-parse --short HEAD) \
        --tag $IMAGE_NAME .


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The image source for caching in automated builds now points to `nbisweden` DockerHub repository.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Trigger for builds has been created in NBISweden's DockerHub repository.
3) The image source for caching in automated builds changed.
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
